### PR TITLE
Fixes issue #20 by adding a check for null

### DIFF
--- a/Auxilliaries.gs
+++ b/Auxilliaries.gs
@@ -112,6 +112,9 @@ function rowIsEmpty(a, row) {
  */
 function columnIsEmpty(a, col) {
   for (var row in a[0]) {
+    if (a[row] == null) {
+      return true;
+    }
     if (a[row][col] !== "" && a[row][col] !== undefined) {
       return false;
     }


### PR DESCRIPTION
Add a check for a null object (column) before checking the values of the cells.

This happens when a passed range is larger than the available data -- that is, there are columns included in the range that have no data.